### PR TITLE
remove scrollbar caused by long text

### DIFF
--- a/src/components/IncidentsList/IncidentsListItem.vue
+++ b/src/components/IncidentsList/IncidentsListItem.vue
@@ -112,6 +112,7 @@ export default {
 }
 
 .content {
+  overflow-x: hidden;
   padding: var(--spacing-xs);
 }
 


### PR DESCRIPTION
A dirty hack to remove the scrollbar. The latest import also adds long links. Maybe they should be removed from the text in the scheme and add related links as a seperate property. The long links now break the UI and are not clickable.